### PR TITLE
Add Entity:LookupBone cache

### DIFF
--- a/lua/nitrous/optimizations/shared/entity_lookupbone.lua
+++ b/lua/nitrous/optimizations/shared/entity_lookupbone.lua
@@ -1,0 +1,30 @@
+local meta = FindMetaTable( "Entity" )
+
+meta.GMN_LookupBone = GMN.StoreOriginal( "Entity:LookupBone", meta.LookupBone )
+local lookupBone = meta.LookupBone
+
+function meta:LookupBone( boneName )
+    local cache = self.GMN_LookupBoneCache
+    if not cache then
+        cache = {}
+        self.GMN_LookupBoneCache = cache
+    end
+
+    
+    -- If an entity's model changes, surely their bones will too
+    -- We can cache per-model, or we can detect when it changes and clear their cache
+    local modelName = self:GetModel()
+    local modelCache = cache[modelName]
+    if not modelCache then
+        modelCache = {}
+        cache[modelName] = modelCache
+    end
+
+    local cached = modelCache[boneName]
+    if cached then return cached end
+    
+    local result = self:GMN_LookupBone( boneName )
+    modelCache[boneName] = result
+    
+    return result
+end


### PR DESCRIPTION
Addresses a major cause of memory churn / gc load on (at least) clientside

```
> timer.Create( "counter", 0.15, 40, function() print( SysTime(), string.NiceSize( collectgarbage( "count" ) * 1024 ) ) end )
18916.9673409    234.83 MB
18917.1123199    245.82 MB
18917.2641314    257.45 MB
18917.4151194    268.42 MB
18917.5575785    277.35 MB
18917.7131228    287.06 MB
18917.869667    297.36 MB
18918.0315996    289.29 MB
18918.1682716    231.67 MB
18918.3106831    152.13 MB
18918.4682257    160.24 MB
18918.6144795    169.87 MB
18918.756641    179.47 MB
18918.9210528    190.44 MB
18919.0679871    200.06 MB
18919.2121507    209.67 MB
18919.3565428    219.29 MB
```
^ baseline big churn

```
Code ran successfully!
> timer.Create( "counter", 0.15, 40, function() print( SysTime(), string.NiceSize( collectgarbage( "count" ) * 1024 ) ) end )
19022.7804343    176.74 MB
19022.9184949    152.49 MB
19023.0736435    157.64 MB
19023.2264095    162.77 MB
19023.3748628    167.68 MB
19023.5178538    172.98 MB
19023.6752708    178.81 MB
19023.8336166    184.64 MB
19023.976797    189.96 MB
19024.1149051    194.8 MB
19024.2716146    200.59 MB
19024.4379512    206.42 MB
19024.5655278    210.8 MB
19024.7158129    215.67 MB
19024.8690248    221 MB
19025.0177898    225.38 MB
19025.1812236    230.74 MB
19025.3202383    235.11 MB
19025.4716915    239.88 MB
19025.6522131    245.8 MB
19025.7740737    249.69 MB
19025.9303775    255.08 MB
19026.0870143    260.43 MB
19026.221889    264.86 MB
19026.3684383    269.74 MB
```
^ no more big churn with cache applied _(waited a few seconds for the cache to warm up before measuring again)_